### PR TITLE
Add ability to change field colors

### DIFF
--- a/src/main/java/fopbot/Field.java
+++ b/src/main/java/fopbot/Field.java
@@ -1,5 +1,8 @@
 package fopbot;
 
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.Color;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -14,6 +17,8 @@ public class Field {
      * Contains all entities that are on this field.
      */
     private final List<FieldEntity> entities;
+
+    private @Nullable Color fieldColor;
 
     /**
      * Constructs and initializes a field with no entities on it.
@@ -38,5 +43,25 @@ public class Field {
      */
     public List<FieldEntity> getEntities() {
         return entities;
+    }
+
+    /**
+     * Sets the background color of this {@link Field} to the specified color.
+     * <p>If the specified color is {@code null}, the background color of this {@link Field}
+     * will be reset to the default color.</p>
+     *
+     * @param fieldColor the new background color of this {@link Field}
+     */
+    public void setFieldColor(final @Nullable Color fieldColor) {
+        this.fieldColor = fieldColor;
+    }
+
+    /**
+     * Returns the background color of this {@link Field}.
+     *
+     * @return the background color of this {@link Field}
+     */
+    public @Nullable Color getFieldColor() {
+        return fieldColor;
     }
 }

--- a/src/main/java/fopbot/GuiPanel.java
+++ b/src/main/java/fopbot/GuiPanel.java
@@ -209,7 +209,11 @@ class GuiPanel extends JPanel {
         g.setColor(Color.LIGHT_GRAY);
         for (int h = 0; h < world.getHeight(); h++) {
             for (int w = 0; w < world.getWidth(); w++) {
+                if (world.getField(w, World.getHeight() - h - 1).getFieldColor() != null) {
+                    g.setColor(world.getField(w, World.getHeight() - h - 1).getFieldColor());
+                }
                 g.fillRect(width, height, FIELD_INNER_SIZE, FIELD_INNER_SIZE);
+                g.setColor(Color.LIGHT_GRAY);
 
                 if (h == 99) {
                     g.setColor(Color.GREEN);

--- a/src/main/java/fopbot/KarelWorld.java
+++ b/src/main/java/fopbot/KarelWorld.java
@@ -3,7 +3,9 @@ package fopbot;
 
 import fopbot.Transition.RobotAction;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
+import java.awt.Color;
 import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.io.IOException;
@@ -698,5 +700,27 @@ public class KarelWorld {
      */
     public InputHandler getInputHandler() {
         return GraphicsEnvironment.isHeadless() ? null : getGuiPanel().getInputHandler();
+    }
+
+    /**
+     * Sets the color of the field at the specified coordinates.
+     *
+     * @param x     the x coordinate of the field
+     * @param y     the y coordinate of the field
+     * @param color the color to set
+     */
+    public void setFieldColor(int x, int y, @Nullable Color color) {
+        fields[y][x].setFieldColor(color);
+    }
+
+    /**
+     * Returns the color of the field at the specified coordinates or {@code null} if no color is set.
+     *
+     * @param x the x coordinate of the field
+     * @param y the y coordinate of the field
+     * @return the color of the field at the specified coordinates or {@code null} if no color is set
+     */
+    public @Nullable Color getFieldColor(int x, int y) {
+        return fields[y][x].getFieldColor();
     }
 }


### PR DESCRIPTION
This PR adds the Ability to change field colors and mark certain fields as important. Since the colors are saved in the Field itself,  this can also be used in Headless Mode. Might even be used by students in future exercises.