### PR TITLE
Add a removeRobot method to World

### DIFF
--- a/src/main/java/fopbot/KarelWorld.java
+++ b/src/main/java/fopbot/KarelWorld.java
@@ -75,9 +75,13 @@ public class KarelWorld {
      */
     private int delay = 100;
     /**
-     * The number of robots on this world.
+     * The current number of robots on this world.
      */
-    private int robotCount;
+    private int robotCount = 0;
+    /**
+     * The ID of the next robot to be added to the world
+     */
+    private  int nextRobotId = 0;
     /**
      * The graphical user interface window on which the FOP Bot world panel is visible.
      */
@@ -118,15 +122,28 @@ public class KarelWorld {
     }
 
     /**
-     * Adds the specified robot to this world.
+     * Adds the specified {@link Robot} to this world.
      *
      * @param robot the robot to place
      */
     public void addRobot(Robot robot) {
         fields[robot.getY()][robot.getX()].getEntities().add(robot);
-        robot.setId(Integer.toString(robotCount));
+        robot.setId(Integer.toString(nextRobotId));
+        nextRobotId++;
         robotCount++;
         traces.put(robot.getId(), new RobotTrace());
+        triggerUpdate();
+        sleep();
+    }
+
+    /**
+     * Removes the specified {@link Robot} from this world.
+     *
+     * @param robot the robot to remove
+     */
+    public void removeRobot(Robot robot){
+        fields[robot.getY()][robot.getX()].getEntities().remove(robot);
+        robotCount--;
         triggerUpdate();
         sleep();
     }

--- a/src/main/java/fopbot/World.java
+++ b/src/main/java/fopbot/World.java
@@ -157,6 +157,15 @@ public class World {
     }
 
     /**
+     * Removes the specified {@link Robot} from the current world.
+     *
+     * @param robot the robot to remove
+     */
+    public static void removeRobot(Robot robot){
+        world.removeRobot(robot);
+    }
+
+    /**
      * Returns {@code true} if a global world exists.
      *
      * @return {@code true} if a global world exists


### PR DESCRIPTION
This pull request aims to add a removeRobot method to remove a given robot from the world, as this would be a nice feature for the upcoming H02 exercise.
Issue #39 should be properly addressed, though it should be noted that robotCount is currently unused, so it might not be needed.
There are also some minor javadoc improvements.
Robots that have been removed from the world can still be accessed and, for example, moved, this can lead to crashes. How to deal with this is up for discussion as I am unsure what the ideal solution for this is.