### PR TITLE
Add Field Click Event Support

### DIFF
--- a/src/main/java/fopbot/FieldClickEvent.java
+++ b/src/main/java/fopbot/FieldClickEvent.java
@@ -1,0 +1,27 @@
+package fopbot;
+
+/**
+ * A {@link FieldClickEvent} represents a click on a field.
+ */
+public final class FieldClickEvent {
+
+    private final Field field;
+
+    /**
+     * Constructs a {@link FieldClickEvent} with the given field.
+     *
+     * @param field the field
+     */
+    public FieldClickEvent(Field field) {
+        this.field = field;
+    }
+
+    /**
+     * Returns the clicked field.
+     *
+     * @return the field
+     */
+    public Field getField() {
+        return field;
+    }
+}

--- a/src/main/java/fopbot/FieldClickListener.java
+++ b/src/main/java/fopbot/FieldClickListener.java
@@ -1,0 +1,15 @@
+package fopbot;
+
+/**
+ * A {@link FieldClickListener} is a listener for {@link FieldClickEvent}s.
+ */
+public interface FieldClickListener {
+
+
+    /**
+     * Notifies this field click listener about the given field click event.
+     *
+     * @param event the field click event
+     */
+    void onFieldClick(FieldClickEvent event);
+}

--- a/src/main/java/fopbot/InputHandler.java
+++ b/src/main/java/fopbot/InputHandler.java
@@ -3,6 +3,10 @@ package fopbot;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.geom.NoninvertibleTransformException;
+import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -25,6 +29,8 @@ public class InputHandler {
      */
     private final List<KeyListener> listeners = new ArrayList<>();
 
+    private final List<FieldClickListener> fieldClickListeners = new ArrayList<>();
+
     // --Constructors-- //
 
     /**
@@ -34,6 +40,7 @@ public class InputHandler {
      */
     public InputHandler(final GuiPanel panel) {
         handleKeyboardInputs(panel);
+        handleFieldClickEvents(panel);
     }
 
     // --Getters and Setters-- //
@@ -60,6 +67,10 @@ public class InputHandler {
         this.listeners.add(eventHandler);
     }
 
+    public void addFieldClickListener(FieldClickListener screenListener) {
+        this.fieldClickListeners.add(screenListener);
+    }
+
     /**
      * Set up the keyboard handlers for the given panel.
      *
@@ -82,6 +93,30 @@ public class InputHandler {
             @Override
             public void keyTyped(final KeyEvent e) {
                 InputHandler.this.listeners.forEach(keyListener -> keyListener.keyTyped(e));
+            }
+        });
+    }
+
+    private void handleFieldClickEvents(GuiPanel panel) {
+        var world = panel.world;
+        panel.addMouseListener(new MouseAdapter() {
+
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                var transform = PaintUtils.getPanelWorldTransform(panel);
+                var point = new Point2D.Double();
+                try {
+                    transform.inverseTransform(PaintUtils.toPoint2D(e.getPoint()), point);
+                } catch (NoninvertibleTransformException ex) {
+                    throw new RuntimeException(ex);
+                }
+                var x = point.getX();
+                var y = point.getY();
+                if (x < 0 || y < 0 || x >= world.getWidth() || y >= world.getHeight()) {
+                    return;
+                }
+                var event = new FieldClickEvent(world.getField((int) x, (int) y));
+                fieldClickListeners.forEach(l -> l.onFieldClick(event));
             }
         });
     }

--- a/src/main/java/fopbot/InputHandler.java
+++ b/src/main/java/fopbot/InputHandler.java
@@ -67,6 +67,11 @@ public class InputHandler {
         this.listeners.add(eventHandler);
     }
 
+    /**
+     * Adds the screen listener to this input handler.
+     *
+     * @param screenListener the screen listener
+     */
     public void addFieldClickListener(FieldClickListener screenListener) {
         this.fieldClickListeners.add(screenListener);
     }

--- a/src/main/java/fopbot/PaintUtils.java
+++ b/src/main/java/fopbot/PaintUtils.java
@@ -3,6 +3,7 @@ package fopbot;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
 import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -96,5 +97,21 @@ class PaintUtils {
         width += FIELD_INNER_OFFSET;
         height += FIELD_INNER_OFFSET;
         return new Point(width, height);
+    }
+
+    /**
+     * Returns a transform for transforming a point in the unscaled state of the given panel
+     * to the respective point in the scaled state of the given panel.
+     *
+     * @param panel the panel
+     * @return the transform
+     */
+    public static AffineTransform getPanelTransform(GuiPanel panel) {
+        var unscaled = panel.getUnscaledSize();
+        var scaled = panel.getSize();
+        return AffineTransform.getScaleInstance(
+                (double) scaled.width / (double) unscaled.width,
+                (double) scaled.height / (double) unscaled.height
+        );
     }
 }

--- a/src/main/java/fopbot/PaintUtils.java
+++ b/src/main/java/fopbot/PaintUtils.java
@@ -136,6 +136,14 @@ class PaintUtils {
         return transform;
     }
 
+    public static AffineTransform getPanelWorldTransform(GuiPanel panel) {
+        var transform = new AffineTransform();
+        transform.concatenate(getPanelTransform(panel));
+        transform.concatenate(getWorldTransform(panel.world));
+
+        return transform;
+    }
+
     public static Point2D toPoint2D(Point point) {
         return new Point2D.Double(point.getX(), point.getY());
     }

--- a/src/main/java/fopbot/PaintUtils.java
+++ b/src/main/java/fopbot/PaintUtils.java
@@ -33,23 +33,6 @@ class PaintUtils {
     public static final int BOARD_OFFSET = 20;
 
     /**
-     * A transform for transforming a point in the unscaled state of the panel to the corresponding field position.
-     */
-    public static final AffineTransform WORLD_TRANSFORM;
-
-    static {
-        WORLD_TRANSFORM = new AffineTransform();
-        WORLD_TRANSFORM.translate(
-                BOARD_OFFSET + FIELD_BORDER_THICKNESS / 2d,
-                BOARD_OFFSET + FIELD_BORDER_THICKNESS / 2d
-        );
-        WORLD_TRANSFORM.scale(
-                FIELD_BORDER_THICKNESS + FIELD_INNER_SIZE,
-                FIELD_BORDER_THICKNESS + FIELD_INNER_SIZE
-        );
-    }
-
-    /**
      * Returns the size of the board.
      *
      * @param world the world which is necessary for the calculation of the board size
@@ -130,6 +113,27 @@ class PaintUtils {
                 (double) scaled.width / (double) unscaled.width,
                 (double) scaled.height / (double) unscaled.height
         );
+    }
+
+    /**
+     * Returns a transform for transforming a point in the unscaled state of the given panel
+     * to the respective field position in the given world.
+     *
+     * @param world the world
+     * @return the transform
+     */
+    public static AffineTransform getWorldTransform(KarelWorld world) {
+        var h = world.getHeight();
+        var transform = new AffineTransform();
+        transform.translate(
+                BOARD_OFFSET + .5 * FIELD_BORDER_THICKNESS,
+                BOARD_OFFSET + (h + .5) * FIELD_BORDER_THICKNESS + h * FIELD_INNER_SIZE
+        );
+        transform.scale(
+                FIELD_BORDER_THICKNESS + FIELD_INNER_SIZE,
+                -1 * (FIELD_BORDER_THICKNESS + FIELD_INNER_SIZE)
+        );
+        return transform;
     }
 
     public static Point2D toPoint2D(Point point) {

--- a/src/main/java/fopbot/PaintUtils.java
+++ b/src/main/java/fopbot/PaintUtils.java
@@ -114,4 +114,8 @@ class PaintUtils {
                 (double) scaled.height / (double) unscaled.height
         );
     }
+
+    public static Point2D toPoint2D(Point point) {
+        return new Point2D.Double(point.getX(), point.getY());
+    }
 }

--- a/src/main/java/fopbot/PaintUtils.java
+++ b/src/main/java/fopbot/PaintUtils.java
@@ -33,6 +33,23 @@ class PaintUtils {
     public static final int BOARD_OFFSET = 20;
 
     /**
+     * A transform for transforming a point in the unscaled state of the panel to the corresponding field position.
+     */
+    public static final AffineTransform WORLD_TRANSFORM;
+
+    static {
+        WORLD_TRANSFORM = new AffineTransform();
+        WORLD_TRANSFORM.translate(
+                BOARD_OFFSET + FIELD_BORDER_THICKNESS / 2d,
+                BOARD_OFFSET + FIELD_BORDER_THICKNESS / 2d
+        );
+        WORLD_TRANSFORM.scale(
+                FIELD_BORDER_THICKNESS + FIELD_INNER_SIZE,
+                FIELD_BORDER_THICKNESS + FIELD_INNER_SIZE
+        );
+    }
+
+    /**
      * Returns the size of the board.
      *
      * @param world the world which is necessary for the calculation of the board size


### PR DESCRIPTION
Add support for field click events.

A field click now triggers an _field click event_, represented by an object of class _FieldClickEvent_. Such an event is dispatched to all registred _field click listeners_, represented by objects of class _FieldClickListener_. All field click listeners are managed by the corresponding input listener, which is represented by an object of class _InputListener_ and also responsible for handling field clicks. Additionally, class _PaintUtils_ has been extended with new utility functions used by these classes.