### PR TITLE
fix windoof svg querks

### DIFF
--- a/src/main/java/fopbot/PaintUtils.java
+++ b/src/main/java/fopbot/PaintUtils.java
@@ -84,7 +84,12 @@ class PaintUtils {
             final AffineTransformOp afop = new AffineTransformOp(af, AffineTransformOp.TYPE_BILINEAR);
             final BufferedImage rotatedImage = afop.filter(originalBufferedImage, null);
             // scale image
-            final Image scaledImage = rotatedImage.getScaledInstance(imageSize, imageSize, Image.SCALE_SMOOTH);
+            final String osName = System.getProperty("os.name").toLowerCase();
+            final Image scaledImage = rotatedImage.getScaledInstance(
+                imageSize,
+                imageSize,
+                osName.contains("win") ? Image.SCALE_DEFAULT : Image.SCALE_SMOOTH
+            );
 
             rotations[i] = scaledImage;
         }


### PR DESCRIPTION
Windows reeeeealy doesn't like smooth svg scaling:
![image](https://github.com/tudalgo/fopbot/assets/53945743/60dee03d-da3c-4bfd-b02a-87af65dd6517)

This pr fixes #70 