### PR TITLE
fix shapshot mechanism and use osshr credentials

### DIFF
--- a/build-logic/src/main/kotlin/fopbot-publish.gradle.kts
+++ b/build-logic/src/main/kotlin/fopbot-publish.gradle.kts
@@ -14,11 +14,12 @@ extensions.configure<PublishingExtension> {
     repositories {
         maven {
             credentials {
-                username = project.findProperty("sonatypeUsername") as? String
-                password = project.findProperty("sonatypePassword") as? String
+                username = project.findProperty("ossrhUsername") as? String
+                password = project.findProperty("ossrhPassword") as? String
             }
             val releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
             val snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots"
+            version = file("version").readLines().first()
             url = URI(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
         }
     }


### PR DESCRIPTION
The SNAPSHOT mechanism was broken, because the version is somehow undefined. This fixes it, but i feel like there has to be a better way then reading the version twice here.