### PR TITLE
Improved Robot Families

### DIFF
--- a/src/main/java/fopbot/GuiPanel.java
+++ b/src/main/java/fopbot/GuiPanel.java
@@ -27,8 +27,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import javax.imageio.ImageIO;
 import javax.swing.JPanel;
@@ -381,9 +379,6 @@ public class GuiPanel extends JPanel {
         final int directionIndex = r.getDirection().ordinal();
 
         final int targetRobotImageSize = scale(FIELD_INNER_SIZE - FIELD_INNER_OFFSET * 2);
-        if (world.getRobotImageSize() != targetRobotImageSize) {
-            world.rescaleRobotImages(targetRobotImageSize);
-        }
 
         final Image robotImage = r.getRobotFamily().render(
             targetRobotImageSize,

--- a/src/main/java/fopbot/GuiPanel.java
+++ b/src/main/java/fopbot/GuiPanel.java
@@ -385,10 +385,11 @@ public class GuiPanel extends JPanel {
             world.rescaleRobotImages(targetRobotImageSize);
         }
 
-        final Map<String, Image[]> imageMapById = world.getRobotImageMapById(r.getRobotFamily().getIdentifier());
-        Objects.requireNonNull(imageMapById, "robot image was not found");
-        final Image robotImage = imageMapById.get(r.isTurnedOff() ? "off" : "on")[directionIndex];
-
+        final Image robotImage = r.getRobotFamily().render(
+            targetRobotImageSize,
+            directionIndex * 90,
+            r.isTurnedOff()
+        );
         g.drawImage(robotImage, scale(upperLeft.x), scale(upperLeft.y), null);
 
         final Color cBackup = g.getColor();

--- a/src/main/java/fopbot/KarelWorld.java
+++ b/src/main/java/fopbot/KarelWorld.java
@@ -22,9 +22,6 @@ import java.util.stream.Stream;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
 
-import static fopbot.PaintUtils.FIELD_INNER_OFFSET;
-import static fopbot.PaintUtils.FIELD_INNER_SIZE;
-
 /**
  * Represents the FOP Bot world on a graphical user interface.
  */
@@ -52,11 +49,6 @@ public class KarelWorld {
      * The world fields as 2D coordinate system.
      */
     private final Field[][] fields;
-
-    /**
-     * The current image size of the robot textures. This value will be dynamically adjusted if needed.
-     */
-    private int robotImageSize = FIELD_INNER_SIZE - FIELD_INNER_OFFSET * 2;
 
     /**
      * The maximum number of actions that can be performed in this world.
@@ -597,19 +589,6 @@ public class KarelWorld {
         if (fields[oldY][oldX].getEntities().removeIf(entity -> entity == robot)) {
             fields[robot.getY()][robot.getX()].getEntities().add(robot);
         }
-    }
-
-    /**
-     * Returns the current size of the robot images.
-     *
-     * @return the current size of the robot images
-     */
-    int getRobotImageSize() {
-        return robotImageSize;
-    }
-
-    void rescaleRobotImages(final int size) {
-        this.robotImageSize = size;
     }
 
     /**

--- a/src/main/java/fopbot/PaintUtils.java
+++ b/src/main/java/fopbot/PaintUtils.java
@@ -106,12 +106,12 @@ class PaintUtils {
      * @param upRotationOffset the rotation offset in degree
      * @return the loaded, scaled and rotated image.
      */
-    protected static Image[] loadScaleRotateFieldImage(
+    protected static BufferedImage[] loadScaleRotateFieldImage(
         final InputStream inputImage,
         final int upRotationOffset,
         final int targetSize
     ) {
-        final Image[] rotations = new Image[4];
+        final BufferedImage[] rotations = new BufferedImage[4];
         final BufferedImage originalBufferedImage = loadFieldImage(inputImage, 0, targetSize);
 
         int degrees = upRotationOffset;

--- a/src/main/java/fopbot/RobotFamily.java
+++ b/src/main/java/fopbot/RobotFamily.java
@@ -1,82 +1,139 @@
 package fopbot;
 
 import java.awt.Color;
+import java.awt.image.BufferedImage;
 
 /**
  * An enumeration of robot families.
  * A family of robots is uniquely in terms of their appearance.
  */
-public enum RobotFamily {
-    /**
-     * A Blue Triangle robot.
-     */
-    TRIANGLE_BLUE(Color.BLUE),
-    /**
-     * A Teal Square robot.
-     */
-    SQUARE_AQUA(Color.CYAN),
-    /**
-     * A Black Square robot.
-     */
-    SQUARE_BLUE(Color.BLUE),
-    /**
-     * A Green Square robot.
-     */
-    SQUARE_GREEN(Color.GREEN),
-    /**
-     * An Orange Square robot.
-     */
-    SQUARE_ORANGE(Color.ORANGE),
-    /**
-     * A Purple Square robot.
-     */
-    SQUARE_PURPLE(Color.MAGENTA),
-    /**
-     * A Red Square robot.
-     */
-    SQUARE_RED(Color.RED),
-    /**
-     * A Yellow Square robot.
-     */
-    SQUARE_YELLOW(Color.YELLOW),
-    /**
-     * A Black Square robot.
-     */
-    SQUARE_BLACK(Color.BLACK),
-    /**
-     * A White Square robot.
-     */
-    SQUARE_WHITE(Color.WHITE);
-
-    /**
-     * The color of this robot family.
-     */
-    private final Color color;
-
-    /**
-     * Creates a new robot family with the given color.
-     *
-     * @param color the color of the robot family
-     */
-    RobotFamily(final Color color) {
-        this.color = color;
-    }
+public interface RobotFamily {
 
     /**
      * Returns the color of this robot family.
      *
      * @return the color of this robot family
      */
-    public Color getColor() {
-        return color;
-    }
+    Color getColor();
 
     /**
-     * Returns the identifier of this robot family.
+     * Sets the color of this robot family.
      *
-     * @return the identifier of this robot family
+     * @param color the new color
      */
-    public String getIdentifier() {
-        return name().toLowerCase();
-    }
+    void setColor(Color color);
+
+    /**
+     * Renders a robot of this family.
+     *
+     * @param targetSize     the target size of the rendered image in pixels
+     * @param rotationOffset the rotation offset in degrees
+     * @param turnedOff      whether the robot is turned off
+     * @return the rendered robot
+     */
+    BufferedImage render(
+        int targetSize,
+        int rotationOffset,
+        boolean turnedOff
+    );
+
+    /**
+     * Returns the name of this robot family.
+     *
+     * @return the name of this robot family
+     */
+    String getName();
+
+    // default Families
+
+    /**
+     * A teal square robot.
+     */
+    RobotFamily SQUARE_AQUA = new SvgBasedRobotFamily(
+        "SQUARE_AQUA",
+        "/robots/square_aqua_on.svg",
+        "/robots/square_aqua_off.svg",
+        Color.CYAN
+    );
+    /**
+     * A black square robot.
+     */
+    RobotFamily SQUARE_BLACK = new SvgBasedRobotFamily(
+        "SQUARE_BLACK",
+        "/robots/square_black_on.svg",
+        "/robots/square_black_off.svg",
+        Color.BLACK
+    );
+    /**
+     * A blue square robot.
+     */
+    RobotFamily SQUARE_BLUE = new SvgBasedRobotFamily(
+        "SQUARE_BLUE",
+        "/robots/square_blue_on.svg",
+        "/robots/square_blue_off.svg",
+        Color.BLUE
+    );
+    /**
+     * A brown square robot.
+     */
+    RobotFamily SQUARE_GREEN = new SvgBasedRobotFamily(
+        "SQUARE_GREEN",
+        "/robots/square_green_on.svg",
+        "/robots/square_green_off.svg",
+        Color.GREEN
+    );
+    /**
+     * A gray square robot.
+     */
+    RobotFamily SQUARE_ORANGE = new SvgBasedRobotFamily(
+        "SQUARE_ORANGE",
+        "/robots/square_orange_on.svg",
+        "/robots/square_orange_off.svg",
+        Color.ORANGE
+    );
+    /**
+     * A pink square robot.
+     */
+    RobotFamily SQUARE_PURPLE = new SvgBasedRobotFamily(
+        "SQUARE_PURPLE",
+        "/robots/square_purple_on.svg",
+        "/robots/square_purple_off.svg",
+        Color.MAGENTA
+    );
+    /**
+     * A red square robot.
+     */
+    RobotFamily SQUARE_RED = new SvgBasedRobotFamily(
+        "SQUARE_RED",
+        "/robots/square_red_on.svg",
+        "/robots/square_red_off.svg",
+        Color.RED
+    );
+    /**
+     * A white square robot.
+     */
+    RobotFamily SQUARE_WHITE = new SvgBasedRobotFamily(
+        "SQUARE_WHITE",
+        "/robots/square_white_on.svg",
+        "/robots/square_white_off.svg",
+        Color.WHITE
+    );
+    /**
+     * A yellow square robot.
+     */
+    RobotFamily SQUARE_YELLOW = new SvgBasedRobotFamily(
+        "SQUARE_YELLOW",
+        "/robots/square_yellow_on.svg",
+        "/robots/square_yellow_off.svg",
+        Color.YELLOW
+    );
+    /**
+     * A teal triangle robot.
+     */
+    RobotFamily TRIANGLE_BLUE = new SvgBasedRobotFamily(
+        "TRIANGLE_BLUE",
+        "/robots/triangle_blue_on.svg",
+        "/robots/triangle_blue_off.svg",
+        Color.BLUE
+    );
 }

--- a/src/main/java/fopbot/SvgBasedRobotFamily.java
+++ b/src/main/java/fopbot/SvgBasedRobotFamily.java
@@ -1,0 +1,95 @@
+package fopbot;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+/**
+ * A robot family that is based on SVG images.
+ */
+@Getter
+@RequiredArgsConstructor
+public class SvgBasedRobotFamily implements RobotFamily {
+    /**
+     * The name of this {@link RobotFamily}.
+     */
+    private final String name;
+
+    /**
+     * The path to the SVG image of the robot when it is turned on.
+     */
+    private final String svgPathOn;
+
+    /**
+     * The path to the SVG image of the robot when it is turned off.
+     */
+    private final String svgPathOff;
+
+    /**
+     * The color of this {@link RobotFamily}.
+     */
+    private final Color color;
+
+    /**
+     * The size of the last rendered image.
+     */
+    private int imageSize = -1;
+
+    private final BufferedImage[] images = new BufferedImage[8];
+
+    @Override
+    public void setColor(final Color color) {
+        throw new UnsupportedOperationException("SVG based RobotFamilies do not support color changes.");
+    }
+
+    /**
+     * Returns the correct image for the given rotation offset and turned on state.
+     *
+     * @param rotationOffset the rotation offset in degrees. Rounds to the multiple of 90 degrees.
+     * @param turnedOff      whether the robot is turned off
+     * @return the correct image
+     */
+    public BufferedImage getImage(final int rotationOffset, final boolean turnedOff) {
+        return images[rotationOffset / 90 + (turnedOff ? 4 : 0)];
+    }
+
+    @Override
+    public BufferedImage render(
+        final int targetSize,
+        final int rotationOffset,
+        final boolean turnedOff
+    ) {
+        if (targetSize == imageSize && images.length == 8) {
+            return getImage(rotationOffset, turnedOff);
+        }
+        // render the SVG images in all four rotations
+
+        System.arraycopy(
+            PaintUtils.loadScaleRotateFieldImage(
+                getClass().getResourceAsStream(svgPathOn),
+                0,
+                targetSize
+            ),
+            0,
+            this.images,
+            0,
+            4
+        );
+        System.arraycopy(
+            PaintUtils.loadScaleRotateFieldImage(
+                getClass().getResourceAsStream(svgPathOff),
+                0,
+                targetSize
+            ),
+            0,
+            this.images,
+            4,
+            4
+        );
+
+        imageSize = targetSize;
+        return getImage(rotationOffset, turnedOff);
+    }
+}


### PR DESCRIPTION
Fixes #96 

With This PR it is possible to define custom Robot Families like so:
```java
/**
 * A teal triangle robot.
 */
RobotFamily CHESS_QUEEN_BLACK = new SvgBasedRobotFamily(
    "CHESS_QUEEN",
    "/robots/chess_queen_black_on.svg",
    "/robots/chess_queen_black_off.svg",
    Color.BLACK
);
```

You could even implement other renderers than SVG here. Please note that for the provided SvgBasedRobotFamily to work effectively, there should only ever be one instance for the same textures, as if you were to create one instance per robot, it would grab the images once per robot that is rendered. This is a major breaking change, and will likely result in a major version bump.