### PR TITLE
even more theming options

### DIFF
--- a/src/main/java/fopbot/ColorProfile.java
+++ b/src/main/java/fopbot/ColorProfile.java
@@ -10,21 +10,26 @@ import java.util.function.BiFunction;
 /**
  * A color profile for drawing the world.
  *
- * @param backgroundColorLight  the background color in light mode
- * @param backgroundColorDark   the background color in dark mode
- * @param fieldColorLight       the default background color for {@link Field}s in light mode
- * @param fieldColorDark        the default background color for {@link Field}s in dark mode
- * @param customFieldColorPattern a function for creating custom field color patterns, like chess boards
- * @param outerBorderColorLight the color of the outer border in light mode
- * @param outerBorderColorDark  the color of the outer border in dark mode
- * @param innerBorderColorLight the color of the inner border in light mode (not wall)
- * @param innerBorderColorDark  the color of the inner border in dark mode (not wall)
- * @param wallColorLight        the color of {@link Wall}s in light mode
- * @param wallColorDark         the color of {@link Wall}s in dark mode
- * @param coinColorLight        the color of {@link Coin}s in light mode
- * @param coinColorDark         the color of {@link Coin}s in dark mode
- * @param blockColorLight       the color of {@link Block}s in light mode
- * @param blockColorDark        the color of {@link Block}s in dark mode
+ * @param backgroundColorLight      the background color in light mode
+ * @param backgroundColorDark       the background color in dark mode
+ * @param fieldColorLight           the default background color for {@link Field}s in light mode
+ * @param fieldColorDark            the default background color for {@link Field}s in dark mode
+ * @param customFieldColorPattern   a function for creating custom field color patterns, like chess boards
+ * @param outerBorderColorLight     the color of the outer border in light mode
+ * @param outerBorderColorDark      the color of the outer border in dark mode
+ * @param innerBorderColorLight     the color of the inner border in light mode (not wall)
+ * @param innerBorderColorDark      the color of the inner border in dark mode (not wall)
+ * @param wallColorLight            the color of {@link Wall}s in light mode
+ * @param wallColorDark             the color of {@link Wall}s in dark mode
+ * @param coinColorLight            the color of {@link Coin}s in light mode
+ * @param coinColorDark             the color of {@link Coin}s in dark mode
+ * @param blockColorLight           the color of {@link Block}s in light mode
+ * @param blockColorDark            the color of {@link Block}s in dark mode
+ * @param fieldInnerSize            The inner size of a field in a 2D world.
+ * @param fieldBorderThickness      The thickness of the field borders in a 2D world.
+ * @param fieldOuterBorderThickness The thickness of the outer border of the field in a 2D world.
+ * @param fieldInnerOffset          The inner offset of the size of a field in a 2D world.
+ * @param boardOffset               The offset of the board.
  */
 @Builder(toBuilder = true)
 public record ColorProfile(
@@ -42,12 +47,22 @@ public record ColorProfile(
     Color coinColorLight,
     Color coinColorDark,
     Color blockColorLight,
-    Color blockColorDark
+    Color blockColorDark,
+    int fieldInnerSize,
+    int fieldBorderThickness,
+    int fieldOuterBorderThickness,
+    int fieldInnerOffset,
+    int boardOffset
 ) {
     /**
      * The default color profile.
      */
     public static ColorProfile DEFAULT = ColorProfile.builder()
+        .fieldInnerSize(60)
+        .fieldBorderThickness(4)
+        .fieldOuterBorderThickness(4)
+        .fieldInnerOffset(4)
+        .boardOffset(20)
         .backgroundColorLight(Color.WHITE)
         .backgroundColorDark(Color.BLACK)
         .fieldColorLight(Color.LIGHT_GRAY)

--- a/src/main/java/fopbot/KarelWorld.java
+++ b/src/main/java/fopbot/KarelWorld.java
@@ -63,18 +63,27 @@ public class KarelWorld {
      * The fields of this world.
      */
     private List<Field> entityStates;
+
     /**
      * The delay in milliseconds of this world.
      */
     private int delay = 100;
+
     /**
      * The robot ID generator.
      */
     private final PrimitiveIterator.OfInt robotIdGenerator = IntStream.iterate(0, i -> i + 1).iterator();
+
+    /**
+     * The color profile of the graphical user interface.
+     */
+    private ColorProfile colorProfile = ColorProfile.DEFAULT;
+
     /**
      * The graphical user interface window on which the FOP Bot world panel is visible.
      */
     private JFrame guiFrame;
+
     /**
      * The graphical user interface panel on which this world is drawn.
      */
@@ -705,5 +714,23 @@ public class KarelWorld {
             .flatMap(Collection::stream)
             .filter(Robot.class::isInstance)
             .count();
+    }
+
+    /**
+     * Returns the current {@link ColorProfile} that is used to draw the world.
+     *
+     * @return the current {@link ColorProfile} that is used to draw the world
+     */
+    public ColorProfile getColorProfile() {
+        return colorProfile;
+    }
+
+    /**
+     * Sets the {@link ColorProfile} that is used to draw the world to the given value.
+     *
+     * @param colorProfile the new {@link ColorProfile} to use
+     */
+    public void setColorProfile(final ColorProfile colorProfile) {
+        this.colorProfile = colorProfile;
     }
 }

--- a/src/main/java/fopbot/PaintUtils.java
+++ b/src/main/java/fopbot/PaintUtils.java
@@ -24,31 +24,15 @@ import javax.imageio.ImageReadParam;
 public class PaintUtils {
 
     /**
-     * The inner size of a field in a 2D world.
-     */
-    public static final int FIELD_INNER_SIZE = 60;
-    /**
-     * The thickness of the field borders in a 2D world.
-     */
-    public static final int FIELD_BORDER_THICKNESS = 4;
-    /**
-     * The inner offset of the size of a field in a 2D world.
-     */
-    public static final int FIELD_INNER_OFFSET = 4;
-    /**
-     * The offset of the board.
-     */
-    public static final int BOARD_OFFSET = 20;
-
-    /**
      * Returns the size of the board.
      *
      * @param world the world which is necessary for the calculation of the board size
      * @return the size of the board
      */
     public static Point getBoardSize(final KarelWorld world) {
-        final int w = FIELD_BORDER_THICKNESS * (world.getWidth() + 1) + FIELD_INNER_SIZE * world.getWidth();
-        final int h = FIELD_BORDER_THICKNESS * (world.getHeight() + 1) + FIELD_INNER_SIZE * world.getHeight();
+        final ColorProfile cp = world.getColorProfile();
+        final int w = cp.fieldBorderThickness() * (world.getWidth() + 1) + cp.fieldInnerSize() * world.getWidth();
+        final int h = cp.fieldBorderThickness() * (world.getHeight() + 1) + cp.fieldInnerSize() * world.getHeight();
         return new Point(w, h);
     }
 
@@ -133,31 +117,34 @@ public class PaintUtils {
     /**
      * Returns the upper left corner coordinates of a specific field (the field entity is standing on).
      *
-     * @param fe          the entity to check
-     * @param worldHeight the height of the world
+     * @param fe    the entity to check
+     * @param world the world which is necessary for the calculation of the board size
      * @return the upper left corner coordinates of a specific field (the field entity is standing on)
      */
-    public static Point getUpperLeftCornerInField(final FieldEntity fe, final int worldHeight) {
+    public static Point getUpperLeftCornerInField(final FieldEntity fe, final KarelWorld world) {
+        final int worldHeight = world.getHeight();
+        final ColorProfile cp = world.getColorProfile();
         final int yM = Math.abs(fe.getY() - worldHeight + 1);
-        int width = BOARD_OFFSET + FIELD_BORDER_THICKNESS;
-        int height = BOARD_OFFSET + FIELD_BORDER_THICKNESS;
-        width += fe.getX() * (FIELD_BORDER_THICKNESS + FIELD_INNER_SIZE);
-        height += yM * (FIELD_BORDER_THICKNESS + FIELD_INNER_SIZE);
-        width += FIELD_INNER_OFFSET;
-        height += FIELD_INNER_OFFSET;
+        int width = cp.boardOffset() + cp.fieldBorderThickness();
+        int height = cp.boardOffset() + cp.fieldBorderThickness();
+        width += fe.getX() * (cp.fieldBorderThickness() + cp.fieldInnerSize());
+        height += yM * (cp.fieldBorderThickness() + cp.fieldInnerSize());
+        width += cp.fieldInnerOffset();
+        height += cp.fieldInnerOffset();
         return new Point(width, height);
     }
 
     /**
      * Returns the bounds of a specific field (the field entity is standing on).
      *
-     * @param fe          the entity to check
-     * @param worldHeight the height of the world
+     * @param fe    the entity to check
+     * @param world the world which is necessary for the calculation of the board size
      * @return the bounds of a specific field (the field entity is standing on)
      */
-    public static Rectangle getFieldBounds(final FieldEntity fe, final int worldHeight) {
-        final var upperLeft = getUpperLeftCornerInField(fe, worldHeight);
-        final var size = FIELD_INNER_SIZE - FIELD_INNER_OFFSET * 2;
+    public static Rectangle getFieldBounds(final FieldEntity fe, final KarelWorld world) {
+        final var upperLeft = getUpperLeftCornerInField(fe, world);
+        final ColorProfile cp = world.getColorProfile();
+        final var size = cp.fieldInnerSize() - cp.fieldInnerOffset() * 2;
         return new Rectangle(
             upperLeft.x,
             upperLeft.y,
@@ -193,15 +180,16 @@ public class PaintUtils {
      * @return the transform
      */
     public static AffineTransform getWorldTransform(final KarelWorld world) {
+        final ColorProfile cp = world.getColorProfile();
         final var h = world.getHeight();
         final var transform = new AffineTransform();
         transform.translate(
-            BOARD_OFFSET + .5 * FIELD_BORDER_THICKNESS,
-            BOARD_OFFSET + (h + .5) * FIELD_BORDER_THICKNESS + h * FIELD_INNER_SIZE
+            cp.boardOffset() + .5 * cp.fieldBorderThickness(),
+            cp.boardOffset() + (h + .5) * cp.fieldBorderThickness() + h * cp.fieldInnerSize()
         );
         transform.scale(
-            FIELD_BORDER_THICKNESS + FIELD_INNER_SIZE,
-            -1 * (FIELD_BORDER_THICKNESS + FIELD_INNER_SIZE)
+            cp.fieldBorderThickness() + cp.fieldInnerSize(),
+            -1 * (cp.fieldBorderThickness() + cp.fieldInnerSize())
         );
         return transform;
     }


### PR DESCRIPTION
This PR:
- [X] moved the Color Profile to the KarelWorld so it does not depend on the GUIPanel
- [X] added the option to modify the constant variables `FIELD_INNER_SIZE`, `FIELD_BORDER_THICKNESS`,`FIELD_OUTER_BORDER_THICKNESS`,`FIELD_INNER_OFFSET` and `BOARD_OFFSET` in the color Profile (might need to rename to themeConfig in the future)
- [X] improved the way that the borders are drawn with non-default border widths

This allows for proper chess board drawing.
Before (left), After(right)
<img src="https://github.com/tudalgo/fopbot/assets/53945743/1e31cf67-07e3-4007-a309-c312216c7f04" width="350" /><img src="https://github.com/tudalgo/fopbot/assets/53945743/03c9cb6a-4131-4325-ae3d-c16688e7bfbd" width="350" />